### PR TITLE
Fix duplicate id collision breaking SimpleFin token save in Account settings

### DIFF
--- a/static/js/api/account.js
+++ b/static/js/api/account.js
@@ -142,7 +142,7 @@ async function testCrewConnection() {
 function editSimpleFinToken() {
     document.getElementById('simplefin-config-form').style.display = 'block';
     document.getElementById('simplefin-config-display').style.display = 'none';
-    document.getElementById('simplefin-token-input').value = '';
+    document.getElementById('simplefin-update-token-input').value = '';
     document.getElementById('simplefin-error').style.display = 'none';
 }
 
@@ -152,7 +152,7 @@ function editSimpleFinToken() {
 function cancelSimpleFinEdit() {
     document.getElementById('simplefin-config-form').style.display = 'none';
     document.getElementById('simplefin-config-display').style.display = 'block';
-    document.getElementById('simplefin-token-input').value = '';
+    document.getElementById('simplefin-update-token-input').value = '';
     document.getElementById('simplefin-error').style.display = 'none';
 }
 
@@ -160,7 +160,7 @@ function cancelSimpleFinEdit() {
  * Save SimpleFin setup token
  */
 async function saveSimpleFinToken() {
-    const token = document.getElementById('simplefin-token-input').value.trim();
+    const token = document.getElementById('simplefin-update-token-input').value.trim();
     const errorEl = document.getElementById('simplefin-error');
 
     if (!token) {

--- a/templates/partials/views/account.html
+++ b/templates/partials/views/account.html
@@ -97,7 +97,7 @@
                     <div id="simplefin-config-form" style="display: none; margin-top: 16px;">
                         <div style="margin-bottom: 16px;">
                             <label style="display: block; font-weight: 600; margin-bottom: 8px; color: var(--text-dark); font-size: 13px;">Setup Token</label>
-                            <input type="password" id="simplefin-token-input" placeholder="Enter SimpleFin setup token" style="width: 100%; padding: 10px 12px; border: 1px solid var(--border-color); border-radius: 8px; font-family: monospace; font-size: 13px; background: var(--bg-input); color: var(--text-dark); box-sizing: border-box;">
+                            <input type="password" id="simplefin-update-token-input" placeholder="Enter SimpleFin setup token" style="width: 100%; padding: 10px 12px; border: 1px solid var(--border-color); border-radius: 8px; font-family: monospace; font-size: 13px; background: var(--bg-input); color: var(--text-dark); box-sizing: border-box;">
                             <p style="font-size: 12px; color: var(--text-light); margin-top: 6px;">Get your setup token from <a href="https://bridge.simplefin.org/simplefin/claim" target="_blank" style="color: var(--simple-blue);">SimpleFin Bridge</a>.</p>
                         </div>
                         <div id="simplefin-error" style="background: #fee; color: #c00; padding: 10px; border-radius: 8px; margin-bottom: 12px; display: none; font-size: 13px;"></div>


### PR DESCRIPTION
## Problem

Clicking **Save Token** for SimpleFin in the **Account settings** tab throws:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'trim')
    at saveSimpleFinToken (account.js:163)
```

## Root cause

Two different elements share `id="simplefin-token-input"`:

- `templates/partials/views/account.html` — `<input id="simplefin-token-input">` (the actual token field, read by `saveSimpleFinToken()`)
- `templates/partials/views/credit.html` — `<div id="simplefin-token-input">` (a layout wrapper; its real input is `simplefin-token-field`)

Both partials are rendered into the single-page DOM, and `credit.html` is included **before** `account.html` in `templates/index.html`. So `document.getElementById('simplefin-token-input')` returns the **div**, and `.value` is `undefined` → `.value.trim()` throws.

The same collision also silently no-ops the `.value = ''` field clears in `editSimpleFinToken()` and `cancelSimpleFinEdit()` (they clear the div, not the input).

## Fix

Rename the Account-tab input to a unique `simplefin-update-token-input` (matching its `/api/account/simplefin/update-token` endpoint) and update its three references in `static/js/api/account.js`. The Credit view's SimpleFin onboarding flow is left untouched.

- `templates/partials/views/account.html` — input id
- `static/js/api/account.js` — `saveSimpleFinToken`, `editSimpleFinToken`, `cancelSimpleFinEdit`

Duplicate `id`s are invalid HTML; this gives each element a unique id with no behavior change to the Credit flow.